### PR TITLE
kProcess values init function

### DIFF
--- a/include/kernel/kproc.h
+++ b/include/kernel/kproc.h
@@ -27,6 +27,8 @@ struct scenic_kproc_svc
 
 typedef int (*find_cb_t)(u32, void*);
 
+int kProcInit(void);
+
 scenic_kproc *kproc_find_by_id(u32 pid);
 scenic_kproc *kproc_find_by_name(char *name);
 scenic_kproc *kproc_find_by_tid(u64 tid);

--- a/source/kernel/kproc.c
+++ b/source/kernel/kproc.c
@@ -5,16 +5,14 @@
 #include "kernel/kproc.h"
 #include "kernel/kmem.h"
 
-
 u32 kproc_magic = 0xfff2e888;
-u32 kthread_magic = 0;
-
 u32 kproc_svc_offset = 0x90;
 u32 kproc_flags_offset = 0xb0;
 u32 kproc_codeset_offset = 0xb8;
 u32 kproc_pid_offset = 0xbc;
 u32 kproc_main_thread_offset = 0xc8;
 
+u32 kthread_magic = 0;
 u32 kthread_ctx_offset = 0x8c;
 u32 kthread_prev_offset = 0xa0;
 u32 kthread_next_offset = 0xa4;
@@ -31,7 +29,7 @@ int kProcInit(void) {
 
     ret = aptInit();
     if(ret != 0) return 1;
-    ret = APT_CheckNew3DS_System(&isN3ds);
+    ret = APT_CheckNew3DS(&isN3ds);
     if(ret != 0) return 1;
     aptExit();
 	
@@ -43,6 +41,7 @@ int kProcInit(void) {
         kproc_pid_offset = 0xb4;
         kproc_main_thread_offset = 0xc0;
     }
+
     return 0;
 }
 

--- a/source/kernel/kproc.c
+++ b/source/kernel/kproc.c
@@ -5,16 +5,15 @@
 #include "kernel/kproc.h"
 #include "kernel/kmem.h"
 
-// Set to n3DS values. Init somewhere. :(
 
-u32 kproc_magic = 0xfff2e888;
+u32 kproc_magic = 0xfff2d888; //modified from 0xfff2e888
 u32 kthread_magic = 0;
 
-u32 kproc_svc_offset = 0x90;
-u32 kproc_flags_offset = 0xb0;
-u32 kproc_codeset_offset = 0xb8;
-u32 kproc_pid_offset = 0xbc;
-u32 kproc_main_thread_offset = 0xc8;
+u32 kproc_svc_offset = 0x88; //modified from 0x90
+u32 kproc_flags_offset = 0xa8; //modified from 0xb0
+u32 kproc_codeset_offset = 0xb0; //modified from 0xb8
+u32 kproc_pid_offset = 0xb4; //modified from 0xbc
+u32 kproc_main_thread_offset = 0xc0; //modified from 0xc8
 
 u32 kthread_ctx_offset = 0x8c;
 u32 kthread_prev_offset = 0xa0;

--- a/source/kernel/kproc.c
+++ b/source/kernel/kproc.c
@@ -27,22 +27,22 @@ scenic_kproc *kproc_cache[MAX_PROCS] = {0};
 
 int kProcInit(void) {
     u8 isN3ds;
-	u32 ret;
-	
-	ret = aptInit();
-	if(ret != 0) return 1;
+    u32 ret;
+
+    ret = aptInit();
+    if(ret != 0) return 1;
     ret = APT_CheckNew3DS_System(&isN3ds);
-	if(ret != 0) return 1;
-	aptExit();
+    if(ret != 0) return 1;
+    aptExit();
 	
-	if(!isN3ds) {
-	    kproc_magic = 0xfff2d888;
-		kproc_svc_offset = 0x88;
+    if(!isN3ds) {
+        kproc_magic = 0xfff2d888;
+        kproc_svc_offset = 0x88;
         kproc_flags_offset = 0xa8;
         kproc_codeset_offset = 0xb0;
         kproc_pid_offset = 0xb4;
         kproc_main_thread_offset = 0xc0;
-	}
+    }
     return 0;
 }
 

--- a/source/kernel/kproc.c
+++ b/source/kernel/kproc.c
@@ -6,14 +6,14 @@
 #include "kernel/kmem.h"
 
 
-u32 kproc_magic = 0xfff2d888; //modified from 0xfff2e888
+u32 kproc_magic = 0xfff2e888;
 u32 kthread_magic = 0;
 
-u32 kproc_svc_offset = 0x88; //modified from 0x90
-u32 kproc_flags_offset = 0xa8; //modified from 0xb0
-u32 kproc_codeset_offset = 0xb0; //modified from 0xb8
-u32 kproc_pid_offset = 0xb4; //modified from 0xbc
-u32 kproc_main_thread_offset = 0xc0; //modified from 0xc8
+u32 kproc_svc_offset = 0x90;
+u32 kproc_flags_offset = 0xb0;
+u32 kproc_codeset_offset = 0xb8;
+u32 kproc_pid_offset = 0xbc;
+u32 kproc_main_thread_offset = 0xc8;
 
 u32 kthread_ctx_offset = 0x8c;
 u32 kthread_prev_offset = 0xa0;
@@ -24,6 +24,27 @@ u32 kcodeset_name_offset = 0x50;
 u32 kcodeset_tid_offset = 0x5c;
 
 scenic_kproc *kproc_cache[MAX_PROCS] = {0};
+
+int kProcInit(void) {
+    u8 isN3ds;
+	u32 ret;
+	
+	ret = aptInit();
+	if(ret != 0) return 1;
+    ret = APT_CheckNew3DS_System(&isN3ds);
+	if(ret != 0) return 1;
+	aptExit();
+	
+	if(!isN3ds) {
+	    kproc_magic = 0xfff2d888;
+		kproc_svc_offset = 0x88;
+        kproc_flags_offset = 0xa8;
+        kproc_codeset_offset = 0xb0;
+        kproc_pid_offset = 0xb4;
+        kproc_main_thread_offset = 0xc0;
+	}
+    return 0;
+}
 
 int id_callback(u32 candidate, void *dat)
 {


### PR DESCRIPTION
So I put an init function to set the kProcess values accordingly to the console type (n3ds or o3ds).
It work with my test: https://github.com/422404/injectRemoteMemory  :)
